### PR TITLE
Don't stop download after first error

### DIFF
--- a/ModpacksCH.API/Model/CurseForge/SortableGameVersion.cs
+++ b/ModpacksCH.API/Model/CurseForge/SortableGameVersion.cs
@@ -17,6 +17,6 @@ namespace ModpacksCH.API.Model.CurseForge
         public DateTimeOffset GameVersionReleaseDate { get; set; }
 
         [JsonProperty("gameVersionTypeId")]
-        public long GameVersionTypeId { get; set; }
+        public long? GameVersionTypeId { get; set; }
     }
 }

--- a/ModpacksCH/ModpackDownloader.cs
+++ b/ModpacksCH/ModpackDownloader.cs
@@ -40,7 +40,19 @@ namespace ModpacksCH
             Trace.WriteLine($"Download started: {Files.Count} files");
             var Tasks = Files.Select(async (F) =>
             {
-                await DownloadFile(path, F);
+                try
+                {
+                    await DownloadFile(path, F);
+                }
+                catch (Exception ex)
+                {
+                    var line = $"Failed to download file: {F.Name} ({F.Url})";
+                    Console.WriteLine(line); 
+                    Console.WriteLine(ex);
+                    Trace.WriteLine(line);
+                    return;
+                }
+                
                 Interlocked.Increment(ref Count);
                 IP?.Report(Count);
             });


### PR DESCRIPTION
I tried to download FTB Interactions (ID: 5) and ran into json deserialization failure that crash entire process. 
So I fixed fault property and now download will log error and proceed to next file instead of immediate crash.

BTW You can remove all unused json properties to make download more reliable.